### PR TITLE
Mccalluc/just get the first line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v0.0.3](https://pypi.org/project/dataframer/0.0.3/) (Aug 6, 2018)
+
+* Option to just take a single row.
+
 ## [v0.0.2](https://pypi.org/project/dataframer/0.0.2/) (Aug 3, 2018)
 
 * Parse zipped GCT files.

--- a/README.md
+++ b/README.md
@@ -62,13 +62,26 @@ a
 
 ```
 
-Finally, the first column can also be treated as data.
+Alternatively, the first column can also be treated as data.
 ```
 >>> df_info = dataframer.parse(stream, col_zero_index=False)
 >>> df_info.data_frame
    a  b  c
 0  1  2  3
 1  4  5  6
+>>> df_info.label_map is None
+True
+
+```
+
+If you don't want to read the whole file, but instead only the first
+row so you have information on the columns:
+```
+>>> df_info = dataframer.parse(stream, first_row_only=True)
+>>> df_info.data_frame
+   b  c
+a      
+1  2  3
 >>> df_info.label_map is None
 True
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ True
 
 ```
 
-If you don't want to read the whole file, but instead only the first
-row so you have information on the columns:
+If you don't need the whole file, but instead only want the first
+row for column information:
 ```
 >>> df_info = dataframer.parse(stream, first_row_only=True)
 >>> df_info.data_frame

--- a/dataframer/dataframer.py
+++ b/dataframer/dataframer.py
@@ -35,7 +35,8 @@ def sniff(file):
     return SniffResult(compression=compression, is_gct=is_gct, dialect=dialect)
 
 
-def parse(file, col_zero_index=True, keep_strings=False, relabel=False):
+def parse(file, col_zero_index=True, keep_strings=False, relabel=False,
+          first_row_only=False):
     '''
     Given a file handle, try to determine its format and return a DataFrame.
 
@@ -58,6 +59,7 @@ def parse(file, col_zero_index=True, keep_strings=False, relabel=False):
             compression=sniff_result.compression,
             dialect=sniff_result.dialect,
             skiprows=2 if sniff_result.is_gct else 0,
+            nrows=1 if first_row_only else None,
             engine='c'
             # If other parameters were tweaked and it would fall back to the
             # python engine, we'll get an explicit error instead.

--- a/dataframer/dataframer.py
+++ b/dataframer/dataframer.py
@@ -47,9 +47,6 @@ def parse(file, col_zero_index=True, keep_strings=False, relabel=False):
     :return: DataFrameInfo, which contains the DataFrame itself,
     and a dict of labels for the rows, if relabel is True
     '''
-
-    index_col = 0 if col_zero_index else None
-
     sniff_result = sniff(file)
     with warnings.catch_warnings():
         # https://github.com/pandas-dev/pandas/issues/18845
@@ -57,7 +54,7 @@ def parse(file, col_zero_index=True, keep_strings=False, relabel=False):
         warnings.simplefilter('ignore')
         dataframe = read_csv(
             file,
-            index_col=index_col,
+            index_col=0 if col_zero_index else None,
             compression=sniff_result.compression,
             dialect=sniff_result.dialect,
             skiprows=2 if sniff_result.is_gct else 0,

--- a/tests/test_dataframer.py
+++ b/tests/test_dataframer.py
@@ -9,13 +9,21 @@ from dataframer.dataframer import parse
 
 class TestDataFrames(unittest.TestCase):
 
-    def assertEqualDataFrames(self, a, b, message=''):
+    def assert_equal_data_frames(self, a, b, message=''):
         self.assertEqual(a.shape, b.shape, message)
         a_np = np.array(a.values.tolist())
         b_np = np.array(b.values.tolist())
         np.testing.assert_equal(a_np, b_np, message)
         self.assertEqual(a.columns.tolist(), b.columns.tolist(), message)
         self.assertEqual(a.index.tolist(), b.index.tolist(), message)
+
+    def assert_good_parse(self, input_bytes, df_target, label_map_target=None,
+                          kwargs={}, message=None):
+        stream = BytesIO(input_bytes)
+        df_info = parse(stream, **kwargs)
+        self.assert_equal_data_frames(df_info.data_frame, df_target, message)
+        if label_map_target:
+            self.assertEqual(df_info.label_map, label_map_target, message)
 
 
 class TestKwargs(TestDataFrames):
@@ -30,14 +38,6 @@ class TestFileTypes(TestDataFrames):
             columns=['b', 'c'],
             index=[1]
         )
-
-    def assert_good_parse(self, input_bytes, df_target, label_map_target=None,
-                          kwargs={}, message=None):
-        stream = BytesIO(input_bytes)
-        df_info = parse(stream, **kwargs)
-        self.assertEqualDataFrames(df_info.data_frame, df_target, message)
-        if label_map_target:
-            self.assertEqual(df_info.label_map, label_map_target, message)
 
     def test_read_crazy_delimiters(self):
         for c in '~!@#$%^&*|:;':

--- a/tests/test_dataframer.py
+++ b/tests/test_dataframer.py
@@ -1,5 +1,5 @@
-import tempfile
 import unittest
+from io import BytesIO
 
 import numpy as np
 import pandas
@@ -18,7 +18,11 @@ class TestDataFrames(unittest.TestCase):
         self.assertEqual(a.index.tolist(), b.index.tolist(), message)
 
 
-class TestTabularParser(TestDataFrames):
+class TestOptions(TestDataFrames):
+    pass
+
+
+class TestFileTypes(TestDataFrames):
 
     def setUp(self):
         self.target = pandas.DataFrame([
@@ -29,10 +33,8 @@ class TestTabularParser(TestDataFrames):
 
     def assert_file_read(self, input_bytes, df_target, label_map_target=None,
                          kwargs={}, message=None):
-        file = tempfile.NamedTemporaryFile(mode='wb+')
-        file.write(input_bytes)
-        file.seek(0)
-        df_info = parse(file, **kwargs)
+        stream = BytesIO(input_bytes)
+        df_info = parse(stream, **kwargs)
         self.assertEqualDataFrames(df_info.data_frame, df_target, message)
         if label_map_target:
             self.assertEqual(df_info.label_map, label_map_target, message)

--- a/tests/test_dataframer.py
+++ b/tests/test_dataframer.py
@@ -18,7 +18,7 @@ class TestDataFrames(unittest.TestCase):
         self.assertEqual(a.index.tolist(), b.index.tolist(), message)
 
 
-class TestOptions(TestDataFrames):
+class TestKwargs(TestDataFrames):
     pass
 
 
@@ -31,8 +31,8 @@ class TestFileTypes(TestDataFrames):
             index=[1]
         )
 
-    def assert_file_read(self, input_bytes, df_target, label_map_target=None,
-                         kwargs={}, message=None):
+    def assert_good_parse(self, input_bytes, df_target, label_map_target=None,
+                          kwargs={}, message=None):
         stream = BytesIO(input_bytes)
         df_info = parse(stream, **kwargs)
         self.assertEqualDataFrames(df_info.data_frame, df_target, message)
@@ -41,7 +41,7 @@ class TestFileTypes(TestDataFrames):
 
     def test_read_crazy_delimiters(self):
         for c in '~!@#$%^&*|:;':
-            self.assert_file_read(
+            self.assert_good_parse(
                 bytes('{0}b{0}c\n1{0}2{0}3'.format(c), 'utf-8'),
                 self.target,
                 message='Failed with {} as delimiter'.format(c)
@@ -53,17 +53,17 @@ class TestFileTypes(TestDataFrames):
     #   >>> open('fake.csv.gz', 'rb').read()
 
     def test_read_gzip(self):
-        self.assert_file_read(
+        self.assert_good_parse(
             b'\x1f\x8b\x08\x08\xe5\xf2\x82Z\x00\x03fake.csv\x00\xd3I\xd2I\xe62\xd41\xd21\x06\x00\xfb\x9a\xc9\xa6\n\x00\x00\x00', self.target)  # noqa: E501
 
     def test_read_csv(self):
-        self.assert_file_read(b',b,c\n1,2,3', self.target)
+        self.assert_good_parse(b',b,c\n1,2,3', self.target)
 
     def test_read_csv_remove_strings(self):
-        self.assert_file_read(b',b,c,xxx\n1,2,3,X!', self.target)
+        self.assert_good_parse(b',b,c,xxx\n1,2,3,X!', self.target)
 
     def test_read_csv_keep_strings(self):
-        self.assert_file_read(
+        self.assert_good_parse(
             b',b,c,xxx\n1,2,3,X!',
             pandas.DataFrame([
                 [2, 3, 'X!']],
@@ -73,7 +73,7 @@ class TestFileTypes(TestDataFrames):
             kwargs={'keep_strings': True})
 
     def test_read_csv_merge_strings(self):
-        self.assert_file_read(
+        self.assert_good_parse(
             b',b,c,xxx,yyy\n1,2,3,X!,Y!',
             pandas.DataFrame([
                 [2, 3]],
@@ -85,18 +85,18 @@ class TestFileTypes(TestDataFrames):
             kwargs={'relabel': True})
 
     def test_read_csv_rn(self):
-        self.assert_file_read(b',b,c\r\n1,2,3', self.target)
+        self.assert_good_parse(b',b,c\r\n1,2,3', self.target)
 
     def test_read_csv_quoted(self):
-        self.assert_file_read(b',"b","c"\n"1","2","3"', self.target)
+        self.assert_good_parse(b',"b","c"\n"1","2","3"', self.target)
 
     def test_read_tsv(self):
-        self.assert_file_read(b'\tb\tc\n1\t2\t3', self.target)
+        self.assert_good_parse(b'\tb\tc\n1\t2\t3', self.target)
 
     def test_read_gct(self):
-        self.assert_file_read(
+        self.assert_good_parse(
             b'#1.2\n1\t1\nNames\tDescription\tb\tc\n1\tfoo\t2\t3', self.target)
 
     def test_read_gct_gz(self):
-        self.assert_file_read(
+        self.assert_good_parse(
             b'\x1f\x8b\x08\x085\xa3c[\x00\x03fake.gct\x00S6\xd43\xe22\xe44\xe4\xf2K\xccM-\xe6tI-N.\xca,(\xc9\xcc\xcf\xe3L\xe2L\x06\xca\xa4\xe5\xe7s\x1aq\x1a\x03\x00\xe7\xcc\xe5\xe5(\x00\x00\x00', self.target)  # noqa: E501

--- a/tests/test_dataframer.py
+++ b/tests/test_dataframer.py
@@ -27,7 +27,47 @@ class TestDataFrames(unittest.TestCase):
 
 
 class TestKwargs(TestDataFrames):
-    pass
+
+    def test_col_zero_index(self):
+        self.assert_good_parse(
+            b'a,b,c\n1,2,3',
+            pandas.DataFrame([
+                [1, 2, 3]],
+                columns=['a', 'b', 'c'],
+                index=[0]
+            ),
+            kwargs={'col_zero_index': False})
+
+    def test_keep_strings(self):
+        self.assert_good_parse(
+            b',b,c,xxx\n1,2,3,X!',
+            pandas.DataFrame([
+                [2, 3, 'X!']],
+                columns=['b', 'c', 'xxx'],
+                index=[1]
+            ),
+            kwargs={'keep_strings': True})
+
+    def test_relabel(self):
+        self.assert_good_parse(
+            b',b,c,xxx\n1,2,3,X!',
+            pandas.DataFrame([
+                [2, 3]],
+                columns=['b', 'c'],
+                index=[1]
+            ),
+            label_map_target={1: 'X! / 1'},
+            kwargs={'relabel': True})
+
+    def test_first_row_only(self):
+        self.assert_good_parse(
+            b',b,c\n1,2,3\n4,5,6',
+            pandas.DataFrame([
+                [2, 3]],
+                columns=['b', 'c'],
+                index=[1]
+            ),
+            kwargs={'first_row_only': True})
 
 
 class TestFileTypes(TestDataFrames):
@@ -61,28 +101,6 @@ class TestFileTypes(TestDataFrames):
 
     def test_read_csv_remove_strings(self):
         self.assert_good_parse(b',b,c,xxx\n1,2,3,X!', self.target)
-
-    def test_read_csv_keep_strings(self):
-        self.assert_good_parse(
-            b',b,c,xxx\n1,2,3,X!',
-            pandas.DataFrame([
-                [2, 3, 'X!']],
-                columns=['b', 'c', 'xxx'],
-                index=[1]
-            ),
-            kwargs={'keep_strings': True})
-
-    def test_read_csv_merge_strings(self):
-        self.assert_good_parse(
-            b',b,c,xxx,yyy\n1,2,3,X!,Y!',
-            pandas.DataFrame([
-                [2, 3]],
-                columns=['b', 'c'],
-                index=[1]
-            ),
-            label_map_target={1: 'X! / 1'},
-            # We get the first text column, and the original index.
-            kwargs={'relabel': True})
 
     def test_read_csv_rn(self):
         self.assert_good_parse(b',b,c\r\n1,2,3', self.target)

--- a/tests/test_dataframer.py
+++ b/tests/test_dataframer.py
@@ -31,8 +31,8 @@ class TestKwargs(TestDataFrames):
     def test_col_zero_index(self):
         self.assert_good_parse(
             b'a,b,c\n1,2,3',
-            pandas.DataFrame([
-                [1, 2, 3]],
+            pandas.DataFrame(
+                [[1, 2, 3]],
                 columns=['a', 'b', 'c'],
                 index=[0]
             ),
@@ -41,8 +41,8 @@ class TestKwargs(TestDataFrames):
     def test_keep_strings(self):
         self.assert_good_parse(
             b',b,c,xxx\n1,2,3,X!',
-            pandas.DataFrame([
-                [2, 3, 'X!']],
+            pandas.DataFrame(
+                [[2, 3, 'X!']],
                 columns=['b', 'c', 'xxx'],
                 index=[1]
             ),
@@ -51,8 +51,8 @@ class TestKwargs(TestDataFrames):
     def test_relabel(self):
         self.assert_good_parse(
             b',b,c,xxx\n1,2,3,X!',
-            pandas.DataFrame([
-                [2, 3]],
+            pandas.DataFrame(
+                [[2, 3]],
                 columns=['b', 'c'],
                 index=[1]
             ),
@@ -62,8 +62,8 @@ class TestKwargs(TestDataFrames):
     def test_first_row_only(self):
         self.assert_good_parse(
             b',b,c\n1,2,3\n4,5,6',
-            pandas.DataFrame([
-                [2, 3]],
+            pandas.DataFrame(
+                [[2, 3]],
                 columns=['b', 'c'],
                 index=[1]
             ),


### PR DESCRIPTION
- Fix #8: Option to read just first row.
- Add tests which essentially duplicate doc tests, but are more precise.
- Rename methods in tests for clarity.